### PR TITLE
break length of the tox address in profile preview pop-up

### DIFF
--- a/sass/layout/_profile.sass
+++ b/sass/layout/_profile.sass
@@ -128,6 +128,8 @@ $modal-postboard-post-height: 100%
 	margin: 0 15px 0 0
 	font-weight: 500
 	padding: 2px 8px 3px 8px
+	width: 306px
+	margin-bottom: 16px
 	+border-radius(2px)
 
 
@@ -154,3 +156,10 @@ $modal-postboard-post-height: 100%
 			text-decoration: none
 		@extend .ion-tox
 		@extend .ion
+
+
+
+.profile-modal
+	.profile-tox
+		word-wrap: break-word
+		width: 200px


### PR DESCRIPTION
fix

![a](https://user-images.githubusercontent.com/76843085/116150370-f1d92f80-a6eb-11eb-99e4-da65b2d3b948.png)

to 

![b](https://user-images.githubusercontent.com/76843085/116149937-68296200-a6eb-11eb-85f1-154c54730949.png)